### PR TITLE
Fix alpha blending on GNOME 44.2

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 #### Bug Fixes
 
+- Fixed an issue on GNOME 44.2 which caused the effects to look broken. It was caused by [this change](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2650).
 - Fixed an issue which prevented the settings of the Snap of Disintegration effect from being translatable.
 
 ## [Burn My Windows 32](https://github.com/schneegans/Burn-My-Windows/releases/tag/v32)

--- a/src/Shader.js
+++ b/src/Shader.js
@@ -180,7 +180,16 @@ var Shader = GObject.registerClass(
     // We use this vfunc to trigger the update as it allows calling this.get_pipeline() in
     // the handler. This could still be null if called from the updateAnimation() above.
     vfunc_paint_target(...params) {
-      this.emit('update-animation', this._progress);
+
+      // Starting with GNOME 44.2, the alpha channel is not written to by default. We need
+      // to undo this. It is a pity that we have to do this here, as it is not really
+      // required to be done each frame. But it's the only place where we can do it.
+      // https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2650
+      if (utils.shellVersionIsAtLeast(44, 2)) {
+        this.get_pipeline().set_blend(
+          'RGBA = ADD (SRC_COLOR * (SRC_COLOR[A]), DST_COLOR * (1-SRC_COLOR[A]))');
+      }
+
       this.set_uniform_float(this._uProgress, 1, [this._progress]);
       super.vfunc_paint_target(...params);
     }

--- a/src/Shader.js
+++ b/src/Shader.js
@@ -180,6 +180,7 @@ var Shader = GObject.registerClass(
     // We use this vfunc to trigger the update as it allows calling this.get_pipeline() in
     // the handler. This could still be null if called from the updateAnimation() above.
     vfunc_paint_target(...params) {
+      this.emit('update-animation', this._progress);
 
       // Starting with GNOME 44.2, the alpha channel is not written to by default. We need
       // to undo this. It is a pity that we have to do this here, as it is not really


### PR DESCRIPTION
There seems to be a blending issue on GNOME 44.2 (#344). Currently, I have no system to test this, but I guess that [this change](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2650) could be the reason. This PR attempts to undo the changes of that commit for the Burn-My-Windows effect shaders.