### PR TITLE
Fix full-screen effects

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,10 @@ SPDX-License-Identifier: CC-BY-4.0
 
 - Two convenience buttons have been added to the preferences dialog. One allows you to select all effects, the other one allows you to deselect all effects.
 
+#### Bug Fixes
+
+- Some effects (Fire, Incinerate, Energize A, Energize B) are faded towards the edges of the window. This used to look weird when the window is maximized. This has been fixed.
+
 ## [Burn My Windows 35](https://github.com/schneegans/Burn-My-Windows/releases/tag/v35)
 
 **Release Date:** 2023-07-03

--- a/kwin/main.js.in
+++ b/kwin/main.js.in
@@ -122,6 +122,7 @@ class %EFFECT_CLASS% {
         this.setupForcedRoles(window);
 
         effect.setUniform(this.shader, 'uForOpening', 1.0);
+        effect.setUniform(this.shader, 'uIsFullscreen', window.fullScreen ? 1.0 : 0.0);
 
         %ON_ANIMATION_BEGIN%
 
@@ -161,6 +162,7 @@ class %EFFECT_CLASS% {
         this.setupForcedRoles(window);
 
         effect.setUniform(this.shader, 'uForOpening', 0.0);
+        effect.setUniform(this.shader, 'uIsFullscreen', window.fullScreen ? 1.0 : 0.0);
 
         %ON_ANIMATION_BEGIN%
 

--- a/resources/shaders/common.glsl
+++ b/resources/shaders/common.glsl
@@ -20,13 +20,14 @@
 
 // Each shader can access these standard input values:
 
-// vec2  iTexCoord:   Texture coordinates for retrieving the window input color.
-// bool  uForOpening: True if a window-open animation is ongoing, false otherwise.
-// float uProgress:   A value which transitions from 0 to 1 during the animation.
-// float uDuration:   The duration of the current animation in seconds.
-// vec2  uSize:       The size of uTexture in pixels.
-// float uPadding:    The empty area around the actual window (e.g. where the shadow
-//                    is drawn). For now, this will only be set on GNOME.
+// vec2  iTexCoord:     Texture coordinates for retrieving the window input color.
+// bool  uIsFullscreen: True if the window is maximized or in fullscreen mode.
+// bool  uForOpening:   True if a window-open animation is ongoing, false otherwise.
+// float uProgress:     A value which transitions from 0 to 1 during the animation.
+// float uDuration:     The duration of the current animation in seconds.
+// vec2  uSize:         The size of uTexture in pixels.
+// float uPadding:      The empty area around the actual window (e.g. where the shadow
+//                      is drawn). For now, this will only be set on GNOME.
 
 // Furthermore, there are two global methods for reading the window input color and
 // setting the shader output color. Both methods assume straight alpha:
@@ -35,6 +36,7 @@
 // void setOutputColor(vec4 outColor)
 
 uniform bool uForOpening;
+uniform bool uIsFullscreen;
 uniform float uProgress;
 uniform float uDuration;
 
@@ -168,14 +170,18 @@ float easeOutBack(float x, float e) {
 // --------------------------------------------------------------------- edge mask helpers
 
 // This method returns a mask which smoothly transitions towards zero when approaching
-// the window's borders. There is a variant which takes the transition area width in
+// the window's borders. If the window is currently maximized or in fullscreen mode, this
+// will return 1.0 everywhere. There is a variant which takes the transition area width in
 // pixels and one which takes this as a percentage.
 float getEdgeMask(vec2 uv, vec2 maxUV, float fadeWidth) {
   float mask = 1.0;
-  mask *= smoothstep(0.0, 1.0, clamp(uv.x / fadeWidth, 0.0, 1.0));
-  mask *= smoothstep(0.0, 1.0, clamp(uv.y / fadeWidth, 0.0, 1.0));
-  mask *= smoothstep(0.0, 1.0, clamp((maxUV.x - uv.x) / fadeWidth, 0.0, 1.0));
-  mask *= smoothstep(0.0, 1.0, clamp((maxUV.y - uv.y) / fadeWidth, 0.0, 1.0));
+
+  if (!uIsFullscreen) {
+    mask *= smoothstep(0.0, 1.0, clamp(uv.x / fadeWidth, 0.0, 1.0));
+    mask *= smoothstep(0.0, 1.0, clamp(uv.y / fadeWidth, 0.0, 1.0));
+    mask *= smoothstep(0.0, 1.0, clamp((maxUV.x - uv.x) / fadeWidth, 0.0, 1.0));
+    mask *= smoothstep(0.0, 1.0, clamp((maxUV.y - uv.y) / fadeWidth, 0.0, 1.0));
+  }
 
   return mask;
 }

--- a/src/Shader.js
+++ b/src/Shader.js
@@ -75,11 +75,12 @@ var Shader = GObject.registerClass(
       this._time     = 0;
 
       // Store standard uniform locations.
-      this._uForOpening = this.get_uniform_location('uForOpening');
-      this._uProgress   = this.get_uniform_location('uProgress');
-      this._uDuration   = this.get_uniform_location('uDuration');
-      this._uSize       = this.get_uniform_location('uSize');
-      this._uPadding    = this.get_uniform_location('uPadding');
+      this._uForOpening   = this.get_uniform_location('uForOpening');
+      this._uIsFullscreen = this.get_uniform_location('uIsFullscreen');
+      this._uProgress     = this.get_uniform_location('uProgress');
+      this._uDuration     = this.get_uniform_location('uDuration');
+      this._uSize         = this.get_uniform_location('uSize');
+      this._uPadding      = this.get_uniform_location('uPadding');
 
       // Create a timeline to drive the animation.
       this._timeline = new Clutter.Timeline();
@@ -124,9 +125,13 @@ var Shader = GObject.registerClass(
       // This is not necessarily symmetric, but I haven't figured out a way to
       // get the actual values...
       const padding = (actor.width - actor.meta_window.get_frame_rect().width) / 2;
+      const isFullscreen =
+        actor.meta_window.get_maximized() === Meta.MaximizeFlags.BOTH ||
+        actor.meta_window.fullscreen;
 
       this.set_uniform_float(this._uPadding, 1, [padding]);
       this.set_uniform_float(this._uForOpening, 1, [forOpening]);
+      this.set_uniform_float(this._uIsFullscreen, 1, [isFullscreen]);
       this.set_uniform_float(this._uDuration, 1, [duration * 0.001]);
       this.set_uniform_float(this._uSize, 2, [actor.width, actor.height]);
 


### PR DESCRIPTION
This resolves #328. On KDE, this does only works for actual full-screen windows and not for maximized windows due to some API limitations.