### PR TITLE
🪲 Add IntelliJ IDEs to window blacklist on KDE

### DIFF
--- a/kwin/main.js.in
+++ b/kwin/main.js.in
@@ -14,8 +14,13 @@ const blacklist = [
     // All the tooltips of IntelliJ IDEs use the same window class as their main window.
     // This results in many awkward animations, so we have to blacklist them all.
     // See https://github.com/Schneegans/Burn-My-Windows/issues/284 for details.
-    "jetbrains-studio jetbrains-studio", "jetbrains-clion jetbrains-clion",
-    "jetbrains-pycharm-ce jetbrains-pycharm-ce"
+    "jetbrains-studio jetbrains-studio", "jetbrains-aqua jetbrains-aqua", 
+    "jetbrains-clion jetbrains-clion", "jetbrains-datagrip jetbrains-datagrip",
+    "jetbrains-dataspell jetbrains-dataspell", "jetbrains-goland jetbrains-goland",
+    "jetbrains-idea jetbrains-idea", "jetbrains-idea-ce jetbrains-idea-ce",
+    "jetbrains-phpstorm jetbrains-phpstorm", "jetbrains-pycharm jetbrains-pycharm", 
+    "jetbrains-pycharm-ce jetbrains-pycharm-ce", "jetbrains-rider jetbrains-rider",
+    "jetbrains-rubymine jetbrains-rubymine", "jetbrains-webstorm jetbrains-webstorm"
 ];
 
 class %EFFECT_CLASS% {


### PR DESCRIPTION
As discussed here https://github.com/Schneegans/Burn-My-Windows/issues/365 we need to ignore all JetBrains IDEs in Burn-My-Windows effects in KWin for now, because of weird animations on tooltips.

This pull request adds the window class of all of their IDEs to blacklist to prevent effects on them.