### PR TITLE
Make "EanbledByDefault" boolean in metadata.json.in

### DIFF
--- a/kwin/metadata.json.in
+++ b/kwin/metadata.json.in
@@ -13,7 +13,7 @@
      "Id": "%DIR_NAME%",
      "License": "GPLv3",
      "Version": "1.0",
-     "EnabledByDefault": "false",
+     "EnabledByDefault": false,
      "Website": "https://github.com/Schneegans/Burn-My-Windows/",
      "BugReportUrl": "https://github.com/Schneegans/Burn-My-Windows/issues",
      "ServiceTypes": [


### PR DESCRIPTION
Making "EnabledByDefault" boolean instead of string, because newer versions of KWin complains about this. It should be backwards-compatible tho.