### PR TITLE
🪲 Fixes the incinerate effect to be circular instead of the aspect ratio of the window

### DIFF
--- a/resources/shaders/incinerate.frag
+++ b/resources/shaders/incinerate.frag
@@ -78,7 +78,7 @@ void main() {
   // Now we compute a 2D gradient in [0..1] which covers the entire window. The dark
   // regions will be burned first, the bright regions in the end. We mix a radial gradient
   // with some noise. The center of the radial gradient is positioned at uStartPos.
-  float circle = length(iTexCoord - uStartPos);
+  float circle = length((iTexCoord - uStartPos) * (uSize.xy / max(uSize.x, uSize.y)));
 
   vec2 uv = iTexCoord / uScale * uSize / 1.5;
   float smokeNoise =


### PR DESCRIPTION
Currently, the fire propagation of the incinerate effect has the aspect ratio of the window.

https://github.com/user-attachments/assets/9df9425a-007a-471e-86aa-15df93bf4f0b

I feel this is wrong because this in not how fire propagates.
This PR fixes it to be circular.

https://github.com/user-attachments/assets/7c358f2c-aea6-4fcf-9924-3037751c7bfb

What do you think ?