### PR TITLE
[KWIN] Split open/close effects in separate categories

### DIFF
--- a/kwin/build.sh
+++ b/kwin/build.sh
@@ -11,7 +11,7 @@
 #                                  |__/                                                  #
 # -------------------------------------------------------------------------------------- #
 
-# SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+# SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>, redmie <43269604+redmie@users.noreply.github.com>
 # SPDX-License-Identifier: MIT
 
 # This scripts takes the shaders of Burn-My-Windows as well as some other input files from
@@ -42,9 +42,12 @@ done
 # $1: The nick of the effect (e.g. "energize-a")
 # $2: The name of the effect (e.g. "Energize A")
 # $3: A short description of the effect (e.g. "Beam your windows away")
+# $4: open/close keyword
 generate() {
-  generate_impl "$1" "$2" "$3" "kwin5"
-  generate_impl "$1" "$2" "$3" "kwin6"
+  generate_impl "$1" "$2" "$3" "kwin5" open
+  generate_impl "$1" "$2" "$3" "kwin5" close
+  generate_impl "$1" "$2" "$3" "kwin6" open
+  generate_impl "$1" "$2" "$3" "kwin6" close
 }
 
 # This method is called twice for each effect. The parameters are as follows:
@@ -52,10 +55,11 @@ generate() {
 # $2: The name of the effect (e.g. "Energize A")
 # $3: A short description of the effect (e.g. "Beam your windows away")
 # #4: Either "kwin5" or "kwin6".
+# #5: Either "open" or "close".
 generate_impl() {
 
   # We use the nick for the effect's directory name by replacing dashes with underscoares.
-  DIR_NAME="${4}_effect_$(echo "$1" | tr '-' '_')"
+  DIR_NAME="${4}_effect_${5}_$(echo "$1" | tr '-' '_')"
 
   # We transform the nick to CamelCase for the JavaScript class name.
   EFFECT_CLASS="BurnMyWindows$(sed -r 's/(^|-)(\w)/\U\2/g' <<<"$1")Effect"
@@ -96,7 +100,7 @@ generate_impl() {
     ON_ANIMATION_BEGIN=$(tr '/' '\f' < "$1/onAnimationBegin.js")
   fi
 
-  cp main.js.in "$BUILD_DIR/$DIR_NAME/contents/code/main.js"
+  cp ${5}_main.js.in "$BUILD_DIR/$DIR_NAME/contents/code/main.js"
   perl -pi -e "s/%ON_SETTINGS_CHANGE%/$ON_SETTINGS_CHANGE/g;" "$BUILD_DIR/$DIR_NAME/contents/code/main.js"
   perl -pi -e "s/%ON_ANIMATION_BEGIN%/$ON_ANIMATION_BEGIN/g;" "$BUILD_DIR/$DIR_NAME/contents/code/main.js"
   perl -pi -e "s/%EFFECT_CLASS%/$EFFECT_CLASS/g;"             "$BUILD_DIR/$DIR_NAME/contents/code/main.js"
@@ -109,6 +113,8 @@ generate_impl() {
   perl -pi -e "s/%NAME%/$2/g;"            "$BUILD_DIR/$DIR_NAME/metadata.json"
   perl -pi -e "s/%DESCRIPTION%/$3/g;"     "$BUILD_DIR/$DIR_NAME/metadata.json"
   perl -pi -e "s/%DIR_NAME%/$DIR_NAME/g;" "$BUILD_DIR/$DIR_NAME/metadata.json"
+  perl -pi -e "s/%OPENCLOSE%/$5/g;"      "$BUILD_DIR/$DIR_NAME/metadata.json"
+  perl -pi -e "s/%OPENCLOSE_CAP%/${5^}/g;" "$BUILD_DIR/$DIR_NAME/metadata.json"
 
   # Now create the two required shader files. We prepend the common.glsl to each shader.
   # We also define KWIN and KWIN_LEGACY. The code in common.glsl takes some different

--- a/kwin/clean.sh
+++ b/kwin/clean.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Go to the script's directory.
+cd "$( cd "$( dirname "$0" )" && pwd )" || \
+  { echo "ERROR: Could not find kwin directory."; exit 1; }
+# Remove build dir
+rm -Rf _build
+# Remove files
+rm -f kwin5*.tar.gz
+rm -f kwin6*.tar.gz
+rm -f burn_my_windows_kwin6.tar.gz
+rm -f burn_my_windows_kwin5.tar.gz

--- a/kwin/close_main.js.in
+++ b/kwin/close_main.js.in
@@ -27,7 +27,6 @@ class %EFFECT_CLASS% {
     constructor() {
         effect.configChanged.connect(this.loadConfig.bind(this));
         effect.animationEnded.connect(this.cleanupForcedRoles.bind(this));
-        effects.windowAdded.connect(this.slotWindowAdded.bind(this));
         effects.windowClosed.connect(this.slotWindowClosed.bind(this));
         effects.windowDataChanged.connect(this.slotWindowDataChanged.bind(this));
 
@@ -121,42 +120,6 @@ class %EFFECT_CLASS% {
     cleanupForcedRoles(window) {
         window.setData(Effect.WindowForceBackgroundContrastRole, null);
         window.setData(Effect.WindowForceBlurRole, null);
-    }
-
-    slotWindowAdded(window) {
-        if (effects.hasActiveFullScreenEffect) {
-            return;
-        }
-        if (!%EFFECT_CLASS%.shouldAnimateWindow(window)) {
-            return;
-        }
-        if (!window.visible) {
-            return;
-        }
-        if (effect.isGrabbed(window, Effect.WindowAddedGrabRole)) {
-            return;
-        }
-        this.setupForcedRoles(window);
-
-        effect.setUniform(this.shader, 'uForOpening', 1.0);
-        effect.setUniform(this.shader, 'uIsFullscreen', window.fullScreen ? 1.0 : 0.0);
-
-        %ON_ANIMATION_BEGIN%
-
-        window.bmwInAnimation = animate({
-            window: window,
-            curve: QEasingCurve.Linear,
-            duration: this.duration,
-            animations: [
-                {
-                    type: Effect.ShaderUniform,
-                    fragmentShader: this.shader,
-                    uniform: "uProgress",
-                    from: 0.0,
-                    to: 1.0
-                }
-            ]
-        });
     }
 
     slotWindowClosed(window) {

--- a/kwin/metadata.json.in
+++ b/kwin/metadata.json.in
@@ -4,7 +4,7 @@
      "Name": "%NAME%",
      "Description": "%DESCRIPTION%",
      "Icon": "preferences-system-windows-effect-%ICON%",
-     "Category": "Window Open/Close Animation",
+     "Category": "Window %OPENCLOSE_CAP% Animation",
      "Authors": [ 
         { "Name": "Simon Schneegans", "Email": "code@simonschneegans.de" },
         { "Name": "Martin Flöser", "Email": "mgraesslin@kde.org" },
@@ -24,7 +24,7 @@
   "X-KDE-Ordering": "60",
   "X-KDE-PluginKeyword": "%DIR_NAME%",
   "X-KWin-Config-TranslationDomain": "burn-my-windows",
-  "X-KWin-Exclusive-Category": "toplevel-open-close-animation",
+  "X-KWin-Exclusive-Category": "%OPENCLOSE%-animation",
   "X-Plasma-API": "javascript",
   "X-Plasma-MainScript": "code/main.js"
 }

--- a/kwin/open_main.js.in
+++ b/kwin/open_main.js.in
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: Vlad Zahorodnii <vlad.zahorodnii@kde.org>, Martin Flöser <mgraesslin@kde.org>, Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+"use strict";
+
+const blacklist = [
+    // The logout screen has to be animated only by the logout effect.
+    "ksmserver ksmserver",
+    "ksmserver-logout-greeter ksmserver-logout-greeter",
+
+    // KDE Plasma splash screen has to be animated only by the login effect.
+    "ksplashqml ksplashqml",
+
+    // All the tooltips of IntelliJ IDEs use the same window class as their main window.
+    // This results in many awkward animations, so we have to blacklist them all.
+    // See https://github.com/Schneegans/Burn-My-Windows/issues/284 for details.
+    "jetbrains-studio jetbrains-studio", "jetbrains-aqua jetbrains-aqua", 
+    "jetbrains-clion jetbrains-clion", "jetbrains-datagrip jetbrains-datagrip",
+    "jetbrains-dataspell jetbrains-dataspell", "jetbrains-goland jetbrains-goland",
+    "jetbrains-idea jetbrains-idea", "jetbrains-idea-ce jetbrains-idea-ce",
+    "jetbrains-phpstorm jetbrains-phpstorm", "jetbrains-pycharm jetbrains-pycharm", 
+    "jetbrains-pycharm-ce jetbrains-pycharm-ce", "jetbrains-rider jetbrains-rider",
+    "jetbrains-rubymine jetbrains-rubymine", "jetbrains-webstorm jetbrains-webstorm"
+];
+
+class %EFFECT_CLASS% {
+    constructor() {
+        effect.configChanged.connect(this.loadConfig.bind(this));
+        effect.animationEnded.connect(this.cleanupForcedRoles.bind(this));
+        effects.windowAdded.connect(this.slotWindowAdded.bind(this));
+        effects.windowDataChanged.connect(this.slotWindowDataChanged.bind(this));
+
+        this.shader = effect.addFragmentShader(Effect.MapTexture, "%SHADER_NAME%.frag");
+
+        this.loadConfig();
+    }
+
+    // A small helper which can be used to read a hex color string (e.g. #ff3244) from the
+    // settings. This method will return an array of four floating point values
+    // [r, g, b, a]. If the settings key only refers to an rgb value, the alpha component
+    // will be set to 1.0.
+    readRGBAConfig(key) {
+        const color = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})?([a-f\d]{2})?$/i
+                        .exec(effect.readConfig(key, '#ffffff'))
+                        .slice(1)
+                        .filter(x => x !== undefined)
+                        .map(x => parseInt(x, 16) / 255);
+        return color.length == 3 ? [color[0], color[1], color[2], 1.0] :
+                                [color[1], color[2], color[3], color[0]];
+    }
+
+    // A small helper which can be used to read a hex color string (e.g. #ff3244) from the
+    // settings. This method will return an array of three floating point values [r, g, b]
+    // regardless of whether the settings key actually refers to an argb hex string.
+    readRGBConfig(key) {
+        const color = this.readRGBAConfig(key);
+        color.pop();
+        return color;
+    }
+
+    // This is called when the effect is loaded and whenever the settings of the effect
+    // are changed by the user.
+    loadConfig() {
+        this.duration = animationTime(effect.readConfig('Duration', 1000));
+
+        %ON_SETTINGS_CHANGE%
+    }
+
+    static shouldAnimateWindow(window) {
+
+        // We don't want to animate most of plasmashell's windows, yet, some
+        // of them we want to, for example, Task Manager Settings window.
+        // The problem is that all those window share single window class.
+        // So, the only way to decide whether a window should be animated is
+        // to use a heuristic: if a window has decoration, then it's most
+        // likely a dialog or a settings window so we have to animate it.
+        if (window.windowClass == "plasmashell plasmashell"
+                || window.windowClass == "plasmashell org.kde.plasmashell") {
+            return window.hasDecoration;
+        }
+
+        // This is primarily to avoid animating the AltTab popup.
+        // See https://github.com/Schneegans/Burn-My-Windows/issues/384 for details.
+        if (!window.hasDecoration && window.onAllDesktops) {
+            return false
+        }
+
+        if (blacklist.indexOf(window.windowClass) != -1) {
+            return false;
+        }
+
+        if (window.hasDecoration) {
+            return true;
+        }
+
+        // Don't animate combobox popups, tooltips, popup menus, etc.
+        if (window.popupWindow) {
+            return false;
+        }
+
+        // Dont't animate the outline and the screenlocker as it looks bad.
+        if (window.lockScreen || window.outline) {
+            return false;
+        }
+
+        // Override-redirect windows are usually used for user interface
+        // concepts that are not expected to be animated by this effect.
+        if (!window.managed) {
+            return false;
+        }
+
+        return window.normalWindow || window.dialog;
+    }
+
+    setupForcedRoles(window) {
+        window.setData(Effect.WindowForceBackgroundContrastRole, true);
+        window.setData(Effect.WindowForceBlurRole, true);
+    }
+
+    cleanupForcedRoles(window) {
+        window.setData(Effect.WindowForceBackgroundContrastRole, null);
+        window.setData(Effect.WindowForceBlurRole, null);
+    }
+
+    slotWindowAdded(window) {
+        if (effects.hasActiveFullScreenEffect) {
+            return;
+        }
+        if (!%EFFECT_CLASS%.shouldAnimateWindow(window)) {
+            return;
+        }
+        if (!window.visible) {
+            return;
+        }
+        if (effect.isGrabbed(window, Effect.WindowAddedGrabRole)) {
+            return;
+        }
+        this.setupForcedRoles(window);
+
+        effect.setUniform(this.shader, 'uForOpening', 1.0);
+        effect.setUniform(this.shader, 'uIsFullscreen', window.fullScreen ? 1.0 : 0.0);
+
+        %ON_ANIMATION_BEGIN%
+
+        window.bmwInAnimation = animate({
+            window: window,
+            curve: QEasingCurve.Linear,
+            duration: this.duration,
+            animations: [
+                {
+                    type: Effect.ShaderUniform,
+                    fragmentShader: this.shader,
+                    uniform: "uProgress",
+                    from: 0.0,
+                    to: 1.0
+                }
+            ]
+        });
+    }
+
+    slotWindowDataChanged(window, role) {
+        if (role == Effect.WindowAddedGrabRole) {
+            if (window.bmwInAnimation && effect.isGrabbed(window, role)) {
+                cancel(window.bmwInAnimation);
+                delete window.bmwInAnimation;
+                this.cleanupForcedRoles(window);
+            }
+        } else if (role == Effect.WindowClosedGrabRole) {
+            if (window.bmwOutAnimation && effect.isGrabbed(window, role)) {
+                cancel(window.bmwOutAnimation);
+                delete window.bmwOutAnimation;
+                this.cleanupForcedRoles(window);
+            }
+        }
+    }
+}
+
+new %EFFECT_CLASS%();


### PR DESCRIPTION
This PR should fix issues #173 and #519. Each effect is split into an open and a close effect.

Tested on:
```
Operating System: openSUSE Tumbleweed 20250813
KDE Plasma Version: 6.4.4
KDE Frameworks Version: 6.17.0
Qt Version: 6.9.1
Kernel Version: 6.15.8-1-default (64-bit)
Graphics Platform: Wayland
```