### PR TITLE
Reorder uniforms in onSettingsChanged.js for readability

### DIFF
--- a/kwin/fire/onSettingsChanged.js
+++ b/kwin/fire/onSettingsChanged.js
@@ -6,12 +6,10 @@
 // the effect.
 
 effect.setUniform(this.shader, 'uDuration', this.duration * 0.001);
-effect.setUniform(this.shader, 'u3DNoise',
-                  effect.readConfig('3DNoise', true) ? 1.0 : 0.0);
-effect.setUniform(this.shader, 'uRandomColor',
-                  effect.readConfig('RandomColor', true) ? 1.0 : 0.0);
 effect.setUniform(this.shader, 'uScale', effect.readConfig('Scale', 1.0));
 effect.setUniform(this.shader, 'uMovementSpeed', effect.readConfig('MovementSpeed', 1.0));
+effect.setUniform(this.shader, 'u3DNoise', effect.readConfig('3DNoise', true) ? 1.0 : 0.0);
+effect.setUniform(this.shader, 'uRandomColor', effect.readConfig('RandomColor', true) ? 1.0 : 0.0);
 effect.setUniform(this.shader, 'uGradient1', this.readRGBAConfig('Gradient1'));
 effect.setUniform(this.shader, 'uGradient2', this.readRGBAConfig('Gradient2'));
 effect.setUniform(this.shader, 'uGradient3', this.readRGBAConfig('Gradient3'));


### PR DESCRIPTION
I made a small rearrangement of the `setUniform` lines to make the file easier to follow. When I first read it, I found it a bit confusing to see how the settings were grouped, but after comparing it with the UI it made more sense. I reordered the lines in a way that feels more logical, so it’s easier to understand at a glance.