### PR TITLE
🪲 Guard WindowManager monkey-patches against init race

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -144,6 +144,9 @@ export default class BurnMyWindows extends Extension {
     }
 
     // We will monkey-patch these methods. Let's store the original ones.
+    if (!Main.wm || typeof Main.wm._shouldAnimateActor !== 'function') {
+      throw new Error('Burn-My-Windows: WindowManager not ready, skipping monkey-patch');
+    }
     this._origShouldAnimateActor    = Main.wm._shouldAnimateActor;
     this._origWaitForOverviewToHide = Main.wm._waitForOverviewToHide;
     this._origAddWindowClone        = Workspace.prototype._addWindowClone;
@@ -351,8 +354,12 @@ export default class BurnMyWindows extends Extension {
     Workspace.prototype._addWindowClone = this._origAddWindowClone;
     Workspace.prototype._windowRemoved  = this._origWindowRemoved;
     Workspace.prototype._doRemoveWindow = this._origDoRemoveWindow;
-    Main.wm._shouldAnimateActor         = this._origShouldAnimateActor;
-    Main.wm._waitForOverviewToHide      = this._origWaitForOverviewToHide;
+    if (typeof this._origShouldAnimateActor === 'function') {
+      Main.wm._shouldAnimateActor = this._origShouldAnimateActor;
+    }
+    if (typeof this._origWaitForOverviewToHide === 'function') {
+      Main.wm._waitForOverviewToHide = this._origWaitForOverviewToHide;
+    }
 
     WindowPreview.prototype._deleteAll = this._origDeleteAll;
     WindowPreview.prototype._restack   = this._origRestack;


### PR DESCRIPTION
## Problem

When Burn-My-Windows is enabled alongside other window animation extensions (e.g. **Compiz windows effect**), a race condition can occur during shell initialization where `Main.wm._shouldAnimateActor` is not yet a function when `enable()` runs. This stale/corrupt reference gets stored as `_origShouldAnimateActor` and later restored during `disable()`, overwriting the real function with a non-function value.

This causes errors like:
```
JS ERROR: TypeError: this._shouldAnimateActor is not a function
JS ERROR: TypeError: can't access property "bind", this._windowRemoved is undefined
```

## Fix

- **enable()**: Skip monkey-patching entirely if `Main.wm` or `_shouldAnimateActor` isn't ready
- **disable()**: Only restore original functions if they're actually valid functions (not undefined/null from a failed init)

## Testing

Tested on GNOME Shell 50.1 (Wayland) with both Burn-My-Windows v48 and Compiz windows effect v31 enabled. The error no longer appears after shell restart.